### PR TITLE
Move highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the "easy-highlight" extension will be documented in this
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [Unreleased]
+### 1.0.0 July 20th 2020
 
-- Initial release
+Initial release of Easy Highlight
+
+### 1.1.0 July 25th 2020
+
+Update Background
+
+### 1.2.0 February 28th 2021
+
+Fixed highlights not being updated when adding text to the document

--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ This extension contributes the following settings:
 
 Initial release of Easy Highlight
 
+### 1.1.0
+
+Update Background
+
+### 1.2.0
+
+Fixed highlights not being updated when adding text to the document
+

--- a/README.md
+++ b/README.md
@@ -34,5 +34,11 @@ Update Background
 
 ### 1.2.0
 
-Fixed highlights not being updated when adding text to the document
+Highlights updated when new text is added or removed. 
+
+## Known Issues:
+- Selecting a single character and typing a single character reduces highlight range.
+- Newlines added or removed within highlight range causes unexpected behavior.
+- Multiline highlights end line will increase when typing.
+
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "easy-highlight",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"type": "git",
 		"url": "https://github.com/BrandonBlaschke/vscode-easy-highlight"
 	},
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"author": {
 		"name": "Brandon Blaschke"
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,10 +173,17 @@ export function activate(context: vscode.ExtensionContext) {
 	vscode.workspace.onDidChangeTextDocument(event => {
 		if (activeEditor && event.document === activeEditor.document) {
 			const path = activeEditor.document.uri.path.toString();
-			if (event.contentChanges.length > 0) {
-				utils.moveRanges(activeEditor, event.contentChanges[0].range, path, recorder);
+			
+			for (const change of event.contentChanges) {
+				const startLine = change.range.start.line;
+				const endLine = change.range.end.line;
+				const linesInRange = endLine - startLine;
+				const linesInserted = change.text.split("\n").length - 1;
+				const diff = linesInserted - linesInRange;
+				utils.moveRanges(activeEditor, change.range, path, diff, linesInserted, recorder);
+				updateDecorations(activeEditor);
 			}
-			updateDecorations(activeEditor);
+			
 		}
 	}, null, context.subscriptions);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -175,12 +175,7 @@ export function activate(context: vscode.ExtensionContext) {
 			const path = activeEditor.document.uri.path.toString();
 			
 			for (const change of event.contentChanges) {
-				const startLine = change.range.start.line;
-				const endLine = change.range.end.line;
-				const linesInRange = endLine - startLine;
-				const linesInserted = change.text.split("\n").length - 1;
-				const diff = linesInserted - linesInRange;
-				utils.moveRanges(activeEditor, change.range, path, diff, linesInserted, recorder);
+				utils.moveRanges(change, path, recorder);
 				updateDecorations(activeEditor);
 			}
 			

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -169,9 +169,11 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 	}, null, context.subscriptions);
 
-	// When editor switches text documents update ActiveEditor and decorations.
+	// When text is added to active editor update any highlights that should be moved up/down
 	vscode.workspace.onDidChangeTextDocument(event => {
 		if (activeEditor && event.document === activeEditor.document) {
+			const path = activeEditor.document.uri.path.toString();
+			utils.moveRanges(event.contentChanges[0].range, path, recorder);
 			updateDecorations(activeEditor);
 		}
 	}, null, context.subscriptions);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,7 +173,9 @@ export function activate(context: vscode.ExtensionContext) {
 	vscode.workspace.onDidChangeTextDocument(event => {
 		if (activeEditor && event.document === activeEditor.document) {
 			const path = activeEditor.document.uri.path.toString();
-			utils.moveRanges(event.contentChanges[0].range, path, recorder);
+			if (event.contentChanges.length > 0) {
+				utils.moveRanges(activeEditor, event.contentChanges[0].range, path, recorder);
+			}
 			updateDecorations(activeEditor);
 		}
 	}, null, context.subscriptions);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -11,15 +11,15 @@ suite('Extension Test Suite', () => {
 	test('Test generateRangeKey', () => {
 		// Different lines from start
 		let key = utils.generateRangeKey(new vscode.Position(0, 0), new vscode.Position(10, 0));
-		assert.equal(key, "00100");
+		assert.strictEqual(key, "00100");
 
 		// Same line in 100s
 		key = utils.generateRangeKey(new vscode.Position(110, 15), new vscode.Position(110, 17));
-		assert.equal(key, "1101511017");
+		assert.strictEqual(key, "1101511017");
 
 		// Both different line and character
 		key = utils.generateRangeKey(new vscode.Position(5, 5), new vscode.Position(6, 6));
-		assert.equal(key, "5566");
+		assert.strictEqual(key, "5566");
 	});
 
 	test('Test modifyRange with outside positions', () => {
@@ -112,15 +112,15 @@ suite('Extension Test Suite', () => {
 
 	test('Test Recorder getFileRange', () => {
 		let recorder = new Recorder();
-		assert.equal(recorder.getFileRange("file path", "range"), undefined);
+		assert.strictEqual(recorder.getFileRange("file path", "range"), undefined);
 		recorder.setFile("file path", {range: "range"});
-		assert.equal(recorder.getFileRange("file path", "range"), "range");
+		assert.strictEqual(recorder.getFileRange("file path", "range"), "range");
 	});
 
 	test('Test Recorder addFileRange', () => {
 		let recorder = new Recorder();
 		let range = new vscode.Range(new vscode.Position(0,0), new vscode.Position(1,0));
-		assert.equal(recorder.addFileRange("file path", "range", range, decoration, "color"), undefined);
+		assert.strictEqual(recorder.addFileRange("file path", "range", range, decoration, "color"), undefined);
 		recorder.setFile("file path", {range: "range"});
 		assert.ok(recorder.hasFileRange("file path", "range"));
 	});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,14 +114,14 @@ export let getConfigColor = (): string => {
  * @param filePath Path to the file that the new range is associated with.
  * @param recorder Recorder Object.
  */
-export let moveRanges = (range: vscode.Range, filePath: string, recorder: Recorder): void => {
+export let moveRanges = (activeEditor: vscode.TextEditor, range: vscode.Range, filePath: string, recorder: Recorder): void => {
     let rangeItems = recorder.getFileRanges(filePath);
-    for (let key in Object.keys(rangeItems)) {
+    for (let key in rangeItems) {
         let highlightRange = rangeItems[key].range;
         
         // if added text on same line as highlight and its before the highlight, bump highlight by its length
-        if (range.isSingleLine && highlightRange.start.line == range.start.line && highlightRange.start.character >= range.end.character) {
-            let length = range.end.character - range.start.character;
+        if (range.isSingleLine && highlightRange.start.line === range.start.line && highlightRange.start.character >= range.end.character) {
+            let length = range.end.character - range.start.character + 1;
 
             let rangeObj = new vscode.Range(
                 new vscode.Position(highlightRange.start.line, highlightRange.start.character + length),
@@ -129,8 +129,13 @@ export let moveRanges = (range: vscode.Range, filePath: string, recorder: Record
             let rangeKey = generateRangeKey(rangeObj.start, rangeObj.end);
             
             // Add new range and remove the old range
-            recorder.addFileRange(filePath, rangeKey, rangeObj, rangeItems[key].decoration, rangeItems[key].color);
+            rangeItems[key].decoration.dispose();
+            const decoration = vscode.window.createTextEditorDecorationType({
+                backgroundColor: DEFAULT_COLOR,
+            });
+            recorder.addFileRange(filePath, rangeKey, rangeObj, decoration, rangeItems[key].color);
             recorder.removeFileRange(filePath, key);
+            console.log(recorder.getFileRanges(filePath));
         }
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -143,11 +143,12 @@ export const moveRanges = (changeEvent: vscode.TextDocumentContentChangeEvent, f
     const diff = linesInserted - linesInRange;
     const range = changeEvent.range;
 
-    // Current Issues with highlighter:
+    // Current Issues with highlighter to be fixed:
     // Issue when highlight is on multiple lines and you type in it when the last line highlight was removed
     // selecting character and then typing a character moves highlight range by one when it shouldn't, rare case
-    // Making a new line then backspacing doesn't always revert back to the original highlight
+    // Making a new line then backspacing will remove a highlight
     // Issue when make new line on multiline highlight at start line
+    // Highlight that was on multiple lines will sometimes move the end highlight line. 
 
     for (let key in rangeItems) {
         const highlightRange = rangeItems[key].range;
@@ -164,7 +165,7 @@ export const moveRanges = (changeEvent: vscode.TextDocumentContentChangeEvent, f
                 }
                 
                 // If new lines added within highlight
-                if (diff !== 0) {
+                if (diff > 0) {
                     const rangeObj1 = new vscode.Range(
                         new vscode.Position(highlightRange.start.line, highlightRange.start.character),
                         new vscode.Position(highlightRange.end.line, range.start.character));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,6 +107,17 @@ export let getConfigColor = (): string => {
     return DEFAULT_COLOR;
 };
 
+const updateHighlight = (newRange: vscode.Range, oldDecoration: vscode.TextEditorDecorationType,
+    filePath: string, oldKey:string, color: string, recorder: Recorder): void => {
+    const rangeKey = generateRangeKey(newRange.start, newRange.end);
+    oldDecoration.dispose();
+    const newDecoration = vscode.window.createTextEditorDecorationType({
+        backgroundColor: color,
+    });
+    recorder.addFileRange(filePath, rangeKey, newRange, newDecoration, color);
+    recorder.removeFileRange(filePath, oldKey);
+};
+
 /**
  * Moves all highlight ranges by the length of the new range provided in the file filePath, if it should be updated.
  * @param changeEvent Change event that occurred
@@ -146,7 +157,8 @@ export let moveRanges = (changeEvent: vscode.TextDocumentContentChangeEvent, fil
                         new vscode.Position(highlightRange.start.line, highlightRange.start.character),
                         new vscode.Position(highlightRange.end.line, range.start.character));
                     let rangeKey1 = generateRangeKey(rangeObj1.start, rangeObj1.end);
-
+                    
+                    // Need to fix highlight here.
                     let rangeObj2 = new vscode.Range(
                         new vscode.Position(highlightRange.start.line + diff, 0),
                         new vscode.Position(highlightRange.end.line + diff, highlightRange.end.character + length));


### PR DESCRIPTION
Added a function to check and move highlights when the user adds or removes text. Few bugs with current implementation, will work on later to resolve as right now I feel this is a good solution that should cover most use cases. 

Known Issues: 
- Selecting a single character and typing a single character reduces highlight range.
- Newlines added or removed within highlight range causes unexpected behavior.
- Multiline highlights end line will increase when typing.